### PR TITLE
Support separate opcp environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,8 +97,10 @@ services:
       - "mqtt://mqtt:1883"
       - "--v2g-pem-file"
       - "/certificates/root-V2G-cert.pem"
-      - "--hubject-token"
-      - "${HUBJECT_TOKEN}"
+      - "--cso-opcp-token"
+      - "${CSO_OPCP_TOKEN}"
+      - "--mo-opcp-token"
+      - "${MO_OPCP_TOKEN}"
       - "--storage-engine"
       - "${STORAGE_ENGINE:-firestore}"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - ":9410"
       - "--mqtt-addr"
       - "mqtt://mqtt:1883"
-      - "--trust-anchor-pem-file"
+      - "--mo-trust-anchor-pem-file"
       - "/certificates/root-V2G-cert.pem"
       - "--cso-opcp-token"
       - "${CSO_OPCP_TOKEN}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - ":9410"
       - "--mqtt-addr"
       - "mqtt://mqtt:1883"
-      - "--v2g-pem-file"
+      - "--trust-anchor-pem-file"
       - "/certificates/root-V2G-cert.pem"
       - "--cso-opcp-token"
       - "${CSO_OPCP_TOKEN}"

--- a/manager/cmd/serve.go
+++ b/manager/cmd/serve.go
@@ -21,17 +21,17 @@ import (
 )
 
 var (
-	mqttAddr        string
-	mqttPrefix      string
-	mqttGroup       string
-	apiAddr         string
-	v2gCertPEMFiles []string
-	csoOPCPToken    string
-	csoOPCPUrl      string
-	moOPCPToken     string
-	moOPCPUrl       string
-	storageEngine   string
-	gcloudProject   string
+	mqttAddr                string
+	mqttPrefix              string
+	mqttGroup               string
+	apiAddr                 string
+	trustAnchorCertPEMFiles []string
+	csoOPCPToken            string
+	csoOPCPUrl              string
+	moOPCPToken             string
+	moOPCPUrl               string
+	storageEngine           string
+	gcloudProject           string
 )
 
 // serveCmd represents the serve command
@@ -62,7 +62,7 @@ the gateway and send appropriate responses.`,
 		apiServer := server.New("api", apiAddr, nil, server.NewApiHandler(engine))
 
 		var v2gCertificates []*x509.Certificate
-		for _, pemFile := range v2gCertPEMFiles {
+		for _, pemFile := range trustAnchorCertPEMFiles {
 			parsedCerts, err := readCertificatesFromPEMFile(pemFile)
 			if err != nil {
 				return fmt.Errorf("reading certificates from PEM file: %s: %v", pemFile, err)
@@ -162,7 +162,7 @@ func init() {
 		"The MQTT group to use for the shared subscription, e.g. manager")
 	serveCmd.Flags().StringVarP(&apiAddr, "api-addr", "a", "127.0.0.1:9410",
 		"The address that the API server will listen on for connections, e.g. 127.0.0.1:9410")
-	serveCmd.Flags().StringSliceVar(&v2gCertPEMFiles, "v2g-pem-file", []string{},
+	serveCmd.Flags().StringSliceVar(&trustAnchorCertPEMFiles, "trust-anchor-pem-file", []string{},
 		"The set of PEM files containing trusted V2G certificates")
 	serveCmd.Flags().StringVar(&csoOPCPToken, "cso-opcp-token", "",
 		"The token to use when integrating with the CSO OPCP (e.g. Hubject's token)")

--- a/manager/cmd/serve.go
+++ b/manager/cmd/serve.go
@@ -79,14 +79,14 @@ the gateway and send appropriate responses.`,
 		var certSignerService services.CertificateSignerService
 		var certProviderService services.EvCertificateProvider
 		if csoOPCPToken != "" && csoOPCPUrl != "" {
-			certSignerService = services.HubjectCertificateSignerService{
+			certSignerService = services.CPOCertificateSignerService{
 				BaseURL:     csoOPCPUrl,
 				BearerToken: csoOPCPToken,
 				ISOVersion:  services.ISO15118V2,
 			}
-			certProviderService = services.HubjectEvCertificateProvider{
-				BaseURL:     csoOPCPUrl,
-				BearerToken: csoOPCPToken,
+			certProviderService = services.MOEvCertificateProvider{
+				BaseURL:     moOPCPUrl,
+				BearerToken: moOPCPToken,
 			}
 		}
 

--- a/manager/cmd/serve.go
+++ b/manager/cmd/serve.go
@@ -21,17 +21,17 @@ import (
 )
 
 var (
-	mqttAddr                string
-	mqttPrefix              string
-	mqttGroup               string
-	apiAddr                 string
-	trustAnchorCertPEMFiles []string
-	csoOPCPToken            string
-	csoOPCPUrl              string
-	moOPCPToken             string
-	moOPCPUrl               string
-	storageEngine           string
-	gcloudProject           string
+	mqttAddr                  string
+	mqttPrefix                string
+	mqttGroup                 string
+	apiAddr                   string
+	moTrustAnchorCertPEMFiles []string
+	csoOPCPToken              string
+	csoOPCPUrl                string
+	moOPCPToken               string
+	moOPCPUrl                 string
+	storageEngine             string
+	gcloudProject             string
 )
 
 // serveCmd represents the serve command
@@ -62,7 +62,7 @@ the gateway and send appropriate responses.`,
 		apiServer := server.New("api", apiAddr, nil, server.NewApiHandler(engine))
 
 		var v2gCertificates []*x509.Certificate
-		for _, pemFile := range trustAnchorCertPEMFiles {
+		for _, pemFile := range moTrustAnchorCertPEMFiles {
 			parsedCerts, err := readCertificatesFromPEMFile(pemFile)
 			if err != nil {
 				return fmt.Errorf("reading certificates from PEM file: %s: %v", pemFile, err)
@@ -79,12 +79,12 @@ the gateway and send appropriate responses.`,
 		var certSignerService services.CertificateSignerService
 		var certProviderService services.EvCertificateProvider
 		if csoOPCPToken != "" && csoOPCPUrl != "" {
-			certSignerService = services.CPOCertificateSignerService{
+			certSignerService = services.OpcpCpoCertificateSignerService{
 				BaseURL:     csoOPCPUrl,
 				BearerToken: csoOPCPToken,
 				ISOVersion:  services.ISO15118V2,
 			}
-			certProviderService = services.MOEvCertificateProvider{
+			certProviderService = services.OpcpMoEvCertificateProvider{
 				BaseURL:     moOPCPUrl,
 				BearerToken: moOPCPToken,
 			}
@@ -162,8 +162,8 @@ func init() {
 		"The MQTT group to use for the shared subscription, e.g. manager")
 	serveCmd.Flags().StringVarP(&apiAddr, "api-addr", "a", "127.0.0.1:9410",
 		"The address that the API server will listen on for connections, e.g. 127.0.0.1:9410")
-	serveCmd.Flags().StringSliceVar(&trustAnchorCertPEMFiles, "trust-anchor-pem-file", []string{},
-		"The set of PEM files containing trusted V2G certificates")
+	serveCmd.Flags().StringSliceVar(&moTrustAnchorCertPEMFiles, "mo-trust-anchor-pem-file", []string{},
+		"The set of PEM files containing trusted MO certificates")
 	serveCmd.Flags().StringVar(&csoOPCPToken, "cso-opcp-token", "",
 		"The token to use when integrating with the CSO OPCP (e.g. Hubject's token)")
 	serveCmd.Flags().StringVar(&csoOPCPUrl, "cso-opcp-url", "https://open.plugncharge-test.hubject.com",

--- a/manager/cmd/serve.go
+++ b/manager/cmd/serve.go
@@ -26,8 +26,10 @@ var (
 	mqttGroup       string
 	apiAddr         string
 	v2gCertPEMFiles []string
-	hubjectToken    string
-	hubjectUrl      string
+	csoOPCPToken    string
+	csoOPCPUrl      string
+	moOPCPToken     string
+	moOPCPUrl       string
 	storageEngine   string
 	gcloudProject   string
 )
@@ -76,15 +78,15 @@ the gateway and send appropriate responses.`,
 
 		var certSignerService services.CertificateSignerService
 		var certProviderService services.EvCertificateProvider
-		if hubjectToken != "" && hubjectUrl != "" {
+		if csoOPCPToken != "" && csoOPCPUrl != "" {
 			certSignerService = services.HubjectCertificateSignerService{
-				BaseURL:     hubjectUrl,
-				BearerToken: hubjectToken,
+				BaseURL:     csoOPCPUrl,
+				BearerToken: csoOPCPToken,
 				ISOVersion:  services.ISO15118V2,
 			}
 			certProviderService = services.HubjectEvCertificateProvider{
-				BaseURL:     hubjectUrl,
-				BearerToken: hubjectToken,
+				BaseURL:     csoOPCPUrl,
+				BearerToken: csoOPCPToken,
 			}
 		}
 
@@ -162,10 +164,14 @@ func init() {
 		"The address that the API server will listen on for connections, e.g. 127.0.0.1:9410")
 	serveCmd.Flags().StringSliceVar(&v2gCertPEMFiles, "v2g-pem-file", []string{},
 		"The set of PEM files containing trusted V2G certificates")
-	serveCmd.Flags().StringVar(&hubjectToken, "hubject-token", "",
-		"The Hubject Bearer token to use")
-	serveCmd.Flags().StringVar(&hubjectUrl, "hubject-url", "https://open.plugncharge-test.hubject.com",
-		"The Hubject Environment URL")
+	serveCmd.Flags().StringVar(&csoOPCPToken, "cso-opcp-token", "",
+		"The token to use when integrating with the CSO OPCP (e.g. Hubject's token)")
+	serveCmd.Flags().StringVar(&csoOPCPUrl, "cso-opcp-url", "https://open.plugncharge-test.hubject.com",
+		"The Environment URL to integrate with the CSO OPCP (e.g. Hubject's environment)")
+	serveCmd.Flags().StringVar(&moOPCPToken, "mo-opcp-token", "",
+		"The token to use when integrating with the MO OPCP (e.g. Hubject's token)")
+	serveCmd.Flags().StringVar(&moOPCPUrl, "mo-opcp-url", "https://open.plugncharge-test.hubject.com",
+		"The Environment URL to integrate with the MO OPCP (e.g. Hubject's environment)")
 	serveCmd.Flags().StringVarP(&storageEngine, "storage-engine", "s", "firestore",
 		"The storage engine to use for persistence, one of [firestore, inmemory]")
 	serveCmd.Flags().StringVar(&gcloudProject, "gcloud-project", "*detect-project-id*",

--- a/manager/services/certificate_signer.go
+++ b/manager/services/certificate_signer.go
@@ -30,8 +30,8 @@ const (
 	ISO15118V20 ISOVersion = "ISO15118-20"
 )
 
-// The CPOCertificateSignerService issues certificates using the CPO CA
-type CPOCertificateSignerService struct {
+// The OpcpCpoCertificateSignerService issues certificates using the CPO CA
+type OpcpCpoCertificateSignerService struct {
 	BaseURL     string
 	BearerToken string
 	ISOVersion  ISOVersion
@@ -44,7 +44,7 @@ func (h HttpError) Error() string {
 	return fmt.Sprintf("http status: %d", h)
 }
 
-func (h CPOCertificateSignerService) SignCertificate(typ CertificateType, pemEncodedCSR string) (string, error) {
+func (h OpcpCpoCertificateSignerService) SignCertificate(typ CertificateType, pemEncodedCSR string) (string, error) {
 	csr, err := convertCSR(pemEncodedCSR)
 	if err != nil {
 		return "", err

--- a/manager/services/certificate_signer.go
+++ b/manager/services/certificate_signer.go
@@ -30,8 +30,8 @@ const (
 	ISO15118V20 ISOVersion = "ISO15118-20"
 )
 
-// The HubjectCertificateSignerService issues certificates using the Hubject cpo CA
-type HubjectCertificateSignerService struct {
+// The CPOCertificateSignerService issues certificates using the CPO CA
+type CPOCertificateSignerService struct {
 	BaseURL     string
 	BearerToken string
 	ISOVersion  ISOVersion
@@ -44,7 +44,7 @@ func (h HttpError) Error() string {
 	return fmt.Sprintf("http status: %d", h)
 }
 
-func (h HubjectCertificateSignerService) SignCertificate(typ CertificateType, pemEncodedCSR string) (string, error) {
+func (h CPOCertificateSignerService) SignCertificate(typ CertificateType, pemEncodedCSR string) (string, error) {
 	csr, err := convertCSR(pemEncodedCSR)
 	if err != nil {
 		return "", err

--- a/manager/services/certificate_signer_test.go
+++ b/manager/services/certificate_signer_test.go
@@ -126,7 +126,7 @@ func TestHubjectCertificateSignerService(t *testing.T) {
 	server := httptest.NewServer(hubject)
 	defer server.Close()
 
-	hubjectSigner := services.HubjectCertificateSignerService{
+	hubjectSigner := services.CPOCertificateSignerService{
 		BaseURL:     server.URL,
 		BearerToken: "TestToken",
 		ISOVersion:  services.ISO15118V2,

--- a/manager/services/certificate_signer_test.go
+++ b/manager/services/certificate_signer_test.go
@@ -126,7 +126,7 @@ func TestHubjectCertificateSignerService(t *testing.T) {
 	server := httptest.NewServer(hubject)
 	defer server.Close()
 
-	hubjectSigner := services.CPOCertificateSignerService{
+	hubjectSigner := services.OpcpCpoCertificateSignerService{
 		BaseURL:     server.URL,
 		BearerToken: "TestToken",
 		ISOVersion:  services.ISO15118V2,

--- a/manager/services/certificate_validation_hubject_test.go
+++ b/manager/services/certificate_validation_hubject_test.go
@@ -40,7 +40,7 @@ func TestCertificateValidationServiceWithHubjectCertificate(t *testing.T) {
 		t.Fatal("no bearer token for Hubject API - set the HUBJECT_TOKEN environment variable")
 	}
 
-	certSignerService := services.HubjectCertificateSignerService{
+	certSignerService := services.CPOCertificateSignerService{
 		BearerToken: bearerToken,
 		BaseURL:     "https://open.plugncharge-test.hubject.com",
 		ISOVersion:  services.ISO15118V2,
@@ -70,7 +70,7 @@ func TestCertificateValidationServiceWithHubjectCertificateHashes(t *testing.T) 
 		t.Fatal("no bearer token for Hubject API - set the HUBJECT_TOKEN environment variable")
 	}
 
-	certSignerService := services.HubjectCertificateSignerService{
+	certSignerService := services.CPOCertificateSignerService{
 		BearerToken: bearerToken,
 		BaseURL:     "https://open.plugncharge-test.hubject.com",
 		ISOVersion:  services.ISO15118V2,

--- a/manager/services/certificate_validation_hubject_test.go
+++ b/manager/services/certificate_validation_hubject_test.go
@@ -40,7 +40,7 @@ func TestCertificateValidationServiceWithHubjectCertificate(t *testing.T) {
 		t.Fatal("no bearer token for Hubject API - set the HUBJECT_TOKEN environment variable")
 	}
 
-	certSignerService := services.CPOCertificateSignerService{
+	certSignerService := services.OpcpCpoCertificateSignerService{
 		BearerToken: bearerToken,
 		BaseURL:     "https://open.plugncharge-test.hubject.com",
 		ISOVersion:  services.ISO15118V2,
@@ -70,7 +70,7 @@ func TestCertificateValidationServiceWithHubjectCertificateHashes(t *testing.T) 
 		t.Fatal("no bearer token for Hubject API - set the HUBJECT_TOKEN environment variable")
 	}
 
-	certSignerService := services.CPOCertificateSignerService{
+	certSignerService := services.OpcpCpoCertificateSignerService{
 		BearerToken: bearerToken,
 		BaseURL:     "https://open.plugncharge-test.hubject.com",
 		ISOVersion:  services.ISO15118V2,

--- a/manager/services/ev_certificate_provider.go
+++ b/manager/services/ev_certificate_provider.go
@@ -19,7 +19,7 @@ type EvCertificateProvider interface {
 	ProvideCertificate(exiRequest string) (EvCertificate15118Response, error)
 }
 
-type HubjectEvCertificateProvider struct {
+type MOEvCertificateProvider struct {
 	BaseURL     string
 	BearerToken string
 	HttpClient  *http.Client
@@ -47,7 +47,7 @@ type SignedContractDataResponse struct {
 	XsdMsgDefNamespace string `json:"xsdMsgDefNamespace"`
 }
 
-func (h HubjectEvCertificateProvider) ProvideCertificate(exiRequest string) (EvCertificate15118Response, error) {
+func (h MOEvCertificateProvider) ProvideCertificate(exiRequest string) (EvCertificate15118Response, error) {
 	client := h.HttpClient
 	if client == nil {
 		client = http.DefaultClient
@@ -64,7 +64,7 @@ func (h HubjectEvCertificateProvider) ProvideCertificate(exiRequest string) (EvC
 	}
 
 	resp, err := withRetries(func() (*http.Response, error) {
-		req, err := h.hubjectRequest(requestUrl, marshalledBody)
+		req, err := h.moRequest(requestUrl, marshalledBody)
 		if err != nil {
 			return &http.Response{}, fmt.Errorf("requesting certificate: %w", err)
 		}
@@ -120,7 +120,7 @@ func (h HubjectEvCertificateProvider) ProvideCertificate(exiRequest string) (EvC
 	return response, nil
 }
 
-func (h HubjectEvCertificateProvider) hubjectRequest(requestUrl string, marshalledBody []byte) (*http.Request, error) {
+func (h MOEvCertificateProvider) moRequest(requestUrl string, marshalledBody []byte) (*http.Request, error) {
 	req, err := http.NewRequest("POST", requestUrl, bytes.NewReader(marshalledBody))
 	if err != nil {
 		return nil, err

--- a/manager/services/ev_certificate_provider.go
+++ b/manager/services/ev_certificate_provider.go
@@ -19,7 +19,7 @@ type EvCertificateProvider interface {
 	ProvideCertificate(exiRequest string) (EvCertificate15118Response, error)
 }
 
-type MOEvCertificateProvider struct {
+type OpcpMoEvCertificateProvider struct {
 	BaseURL     string
 	BearerToken string
 	HttpClient  *http.Client
@@ -47,7 +47,7 @@ type SignedContractDataResponse struct {
 	XsdMsgDefNamespace string `json:"xsdMsgDefNamespace"`
 }
 
-func (h MOEvCertificateProvider) ProvideCertificate(exiRequest string) (EvCertificate15118Response, error) {
+func (h OpcpMoEvCertificateProvider) ProvideCertificate(exiRequest string) (EvCertificate15118Response, error) {
 	client := h.HttpClient
 	if client == nil {
 		client = http.DefaultClient
@@ -120,7 +120,7 @@ func (h MOEvCertificateProvider) ProvideCertificate(exiRequest string) (EvCertif
 	return response, nil
 }
 
-func (h MOEvCertificateProvider) moRequest(requestUrl string, marshalledBody []byte) (*http.Request, error) {
+func (h OpcpMoEvCertificateProvider) moRequest(requestUrl string, marshalledBody []byte) (*http.Request, error) {
 	req, err := http.NewRequest("POST", requestUrl, bytes.NewReader(marshalledBody))
 	if err != nil {
 		return nil, err

--- a/manager/services/ev_certificate_provider_test.go
+++ b/manager/services/ev_certificate_provider_test.go
@@ -91,7 +91,7 @@ func TestEvCertificateProvider(t *testing.T) {
 	server := httptest.NewServer(&hubject)
 	defer server.Close()
 
-	provider := services.MOEvCertificateProvider{
+	provider := services.OpcpMoEvCertificateProvider{
 		BaseURL:     server.URL,
 		BearerToken: "TestToken",
 	}
@@ -109,7 +109,7 @@ func TestEvCertificateProviderWithFlakyResponses(t *testing.T) {
 	server := httptest.NewServer(&hubject)
 	defer server.Close()
 
-	provider := services.MOEvCertificateProvider{
+	provider := services.OpcpMoEvCertificateProvider{
 		BaseURL:     server.URL,
 		BearerToken: "TestToken",
 	}
@@ -138,7 +138,7 @@ func TestEvCertificateProviderFailureCases(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			provider := services.MOEvCertificateProvider{
+			provider := services.OpcpMoEvCertificateProvider{
 				BaseURL:     server.URL,
 				BearerToken: tc.token,
 			}

--- a/manager/services/ev_certificate_provider_test.go
+++ b/manager/services/ev_certificate_provider_test.go
@@ -91,7 +91,7 @@ func TestEvCertificateProvider(t *testing.T) {
 	server := httptest.NewServer(&hubject)
 	defer server.Close()
 
-	provider := services.HubjectEvCertificateProvider{
+	provider := services.MOEvCertificateProvider{
 		BaseURL:     server.URL,
 		BearerToken: "TestToken",
 	}
@@ -109,7 +109,7 @@ func TestEvCertificateProviderWithFlakyResponses(t *testing.T) {
 	server := httptest.NewServer(&hubject)
 	defer server.Close()
 
-	provider := services.HubjectEvCertificateProvider{
+	provider := services.MOEvCertificateProvider{
 		BaseURL:     server.URL,
 		BearerToken: "TestToken",
 	}
@@ -138,7 +138,7 @@ func TestEvCertificateProviderFailureCases(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			provider := services.HubjectEvCertificateProvider{
+			provider := services.MOEvCertificateProvider{
 				BaseURL:     server.URL,
 				BearerToken: tc.token,
 			}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,15 +4,17 @@ command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
 
-BEARER_TOKEN="$1"
-if [[ "$BEARER_TOKEN" == "" ]]; then
+CSO_OPCP_TOKEN="$1"
+MO_OPCP_TOKEN="$2"
+if [[ "$CSO_OPCP_TOKEN" == "" ]]; then
   echo "You must provide a bearer token"
-  echo "Usage: run.sh <BEARER_TOKEN>"
-  echo "       BEARER_TOKEN can be obtained from the Hubject test environment: "
+  echo "Usage: run.sh <CSO_OPCP_TOKEN> <MO_OPCP_TOKEN>"
+  echo "       CSO_OPCP_TOKEN and MO_OPCP_TOKEN can be obtained from the Hubject test environment: "
   echo "       https://hubject.stoplight.io/docs/open-plugncharge/6bb8b3bc79c2e-authorization-token"
   exit 1
 fi
-BEARER_TOKEN=${BEARER_TOKEN#"Bearer "}
+CSO_OPCP_TOKEN=${CSO_OPCP_TOKEN#"Bearer "}
+MO_OPCP_TOKEN=${MO_OPCP_TOKEN#"Bearer "}
 
 shift
 
@@ -29,4 +31,4 @@ else
   fi
 fi
 
-HUBJECT_TOKEN="Bearer "$BEARER_TOKEN $DOCKER_COMPOSE_CMD up "$@"
+MO_OPCP_TOKEN="Bearer "$MO_OPCP_TOKEN ;CSO_OPCP_TOKEN="Bearer "$CSO_OPCP_TOKEN ;$DOCKER_COMPOSE_CMD up "${@:2}"


### PR DESCRIPTION
An MO and CSO may not be on the same OPCP environment. This pull requests provides more flexibility in terms of configuring the CSMS to enrol CSO & retrieve contract certificates from possibly different backends.

The following changes since commit 17b17629885525c4c9a1679b314536cba7bc1f9d:

  feat: add command for encoding cs password (2023-07-20 08:49:00 +0100)

are available in the Git repository at:

  https://github.com/thoughtworks/maeve-csms support-separate-opcp

for you to fetch changes up to db9ac3cde12427669c82dc453ed9aa4430421550:

  refactor!: Rename v2g-root as abstract trust anchor (2023-07-21 12:39:00 +0100)

----------------------------------------------------------------
Alessio Ferri (3):
      refactor!: Rename cli arguments to separate CPO to MO OPCP
      refactor: Introduce separation of dependency for CPO sign service and MO cert provider
      refactor!: Rename v2g-root as abstract trust anchor

 docker-compose.yml                                      |  8 +++++---
 manager/cmd/serve.go                                    | 50 ++++++++++++++++++++++++++++----------------------
 manager/services/certificate_signer.go                  |  6 +++---
 manager/services/certificate_signer_test.go             |  2 +-
 manager/services/certificate_validation_hubject_test.go |  4 ++--
 manager/services/ev_certificate_provider.go             |  8 ++++----
 manager/services/ev_certificate_provider_test.go        |  6 +++---
 scripts/run.sh                                          | 14 ++++++++------
 8 files changed, 54 insertions(+), 44 deletions(-)
