### PR TITLE
ci: smoke test on manager, bypassing envoy

### DIFF
--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -1,0 +1,22 @@
+name: Smoke test services
+
+on: push
+
+jobs:
+    docker-compose:
+        runs-on: ubuntu-latest
+        steps:
+        - run: sudo snap install --edge httpie
+        - uses: actions/checkout@v3
+        - name: Docker Compose setup
+          run: |
+            (cd config/certificates && make)
+            chmod -R a+r config/certificates # gateway needs this for csms.key
+            docker compose up --wait --detach --quiet-pull
+        - name: Dump docker container logs on failure
+          if: failure()
+          run: docker compose logs
+        - run: docker network inspect maeve-csms
+        - name: Smoke test direct to manager
+          run: http -v --ignore-stdin --check-status POST http://localhost:9910/api/v0/cs/cs001 securityProfile:=2
+        - run: docker compose logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,12 +105,13 @@ services:
         read_only: true
     expose:
       - "9410"
-      - "9411"
     healthcheck:
       test: ["CMD", "/usr/bin/curl", "-s", "--fail", "http://localhost:9410/health"]
       interval: 10s
       timeout: 10s
       retries: 3
+    ports:
+      - "9910:9410"
     user: "10000:10000"
 
   firestore:


### PR DESCRIPTION
Keeping hitting "connection aborted" errors on envoy: https://github.com/kaihendry/maeve-csms/actions/runs/5879813147/job/15944726049

The problem is intermittent and _something_ to do with Docker networking, and might even be conflated by colima not supporting [ipv6 very well locally](https://github.com/abiosoft/colima/issues/583). Instead of going mad, this pull request exposes a port direct to Manager to perform an initial setup.

Next steps are to integrate [pionixdev/everest:2023.7.0...](https://hub.docker.com/r/pionixdev/everest/tags)